### PR TITLE
Added ability to have multiple equipment slots of the same type.

### DIFF
--- a/assets/prefabs/Equipment/Copper/CopperRing.prefab
+++ b/assets/prefabs/Equipment/Copper/CopperRing.prefab
@@ -1,0 +1,20 @@
+{
+    "parent" : "engine:iconItem",
+    "Item" : {
+        "icon" : "Equipment:BronzeDagger"
+    },
+    "DisplayName" : {
+        "name" : "Copper Ring",
+        "description" : "An ornamental ring made out of copper."
+    },
+    "EquipmentItem" : {
+        "level" : 1,
+        "quality" : 3,
+        "type" : "Ring",
+        "location" : "Ring",
+        "attack" : 0,
+        "defense" : 1,
+        "weight" : 0,
+        "speed" : 0
+    }
+}

--- a/assets/ui/BackupScreen.ui
+++ b/assets/ui/BackupScreen.ui
@@ -175,7 +175,7 @@
                     "width": 450,
                     "use-content-height" : true,
                     "position-left": {
-                        "offset": 400
+                        "offset": 425
                     },
                     "position-top": {
                         "offset": 15
@@ -202,7 +202,7 @@
                     {
                         "type": "InventoryGrid",
                         "id": "playerEQInventory",
-                        "maxHorizontalCells" : 1,
+                        "maxHorizontalCells" : 2,
                         "layoutInfo": {
                             "width": 560,
                             "height": 168,

--- a/deltas/engine/prefabs/player/player.prefab
+++ b/deltas/engine/prefabs/player/player.prefab
@@ -1,33 +1,47 @@
 {
     "Equipment": {
+        "numberOfSlots": 9,
         "equipmentSlots": [
             {
                 "name": "Weapon",
-                "type": "Weapon"
+                "type": "Weapon",
+                "itemRefs": [0]
             },
             {
                 "name": "Head",
-                "type": "Head"
+                "type": "Head",
+                "itemRefs": [0]
             },
             {
                 "name": "Body",
-                "type": "Body"
+                "type": "Body",
+                "itemRefs": [0]
             },
             {
                 "name": "Arms",
-                "type": "Arms"
+                "type": "Arms",
+                "itemRefs": [0]
             },
             {
                 "name": "Hands",
-                "type": "Hands"
+                "type": "Hands",
+                "itemRefs": [0]
             },
             {
                 "name": "Legs",
-                "type": "Legs"
+                "type": "Legs",
+                "itemRefs": [0]
             },
             {
                 "name": "Feet",
-                "type": "Feet"
+                "type": "Feet",
+                "itemRefs": [0]
+            },
+            {
+                "name": "Ring",
+                "type": "Ring",
+                "numSlotsOfSameType": 2,
+                "itemRefs": [0, 0]
             }
         ]
     }

--- a/src/main/java/org/terasology/equipment/component/EquipmentComponent.java
+++ b/src/main/java/org/terasology/equipment/component/EquipmentComponent.java
@@ -26,6 +26,9 @@ import java.util.List;
 public final class EquipmentComponent implements Component {
     public EntityRef equipmentInventory = EntityRef.NULL;
 
+    // Total number of inventory slots. Make sure to update when an element of the list below is changed.
+    public int numberOfSlots = 0;
+
     // List of equipment slots. Replace or add a map?
     @Replicate
     public List<EquipmentSlot> equipmentSlots = Lists.newArrayList();

--- a/src/main/java/org/terasology/equipment/component/EquipmentSlot.java
+++ b/src/main/java/org/terasology/equipment/component/EquipmentSlot.java
@@ -15,8 +15,11 @@
  */
 package org.terasology.equipment.component;
 
+import com.google.common.collect.Lists;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.reflection.MappedContainer;
+
+import java.util.List;
 
 @MappedContainer
 public class EquipmentSlot {
@@ -24,4 +27,6 @@ public class EquipmentSlot {
     public String name;
     public String type;
     public EntityRef itemRef = EntityRef.NULL;
+    public int numSlotsOfSameType = 1;
+    public List<EntityRef> itemRefs = Lists.newArrayList();
 }

--- a/src/main/java/org/terasology/equipment/ui/CharacterScreenWindow.java
+++ b/src/main/java/org/terasology/equipment/ui/CharacterScreenWindow.java
@@ -111,9 +111,13 @@ public class CharacterScreenWindow extends BaseInteractionScreen {
         playerEQInventory.setCellOffset(0);
         playerEQInventory.setMaxCellCount(eqC.numberOfSlots);
 
+        // Create list of labels for each equipment slot.
         eqSlotLabels = new ArrayList<UILabel>();
         eqSlotLabelsLayout = find("eqSlotNamesLayout", ColumnLayout.class);
+
+        // Iterate through the list of equipment slots.
         for (EquipmentSlot equipmentSlot : eqC.equipmentSlots) {
+            // For each slot present in this type, add a label to the layout and eqSlotLabels list.
             for (int i = 0; i < equipmentSlot.numSlotsOfSameType; i++) {
                 UILabel newLabel = new UILabel();
 
@@ -203,9 +207,12 @@ public class CharacterScreenWindow extends BaseInteractionScreen {
 
             maxHealth.setText("Health: " + phy.constitution*10);
 
-            int c = 0;
+            int c = 0; // Counter for storing which label in eqSlotLabels to access.
+            // Iterate through the list of equipment slots.
             for (int i = 0; (i < eq.equipmentSlots.size()); i++) {
+                // For each slot present in this type.
                 for (int j = 0; j < eq.equipmentSlots.get(i).numSlotsOfSameType; j++) {
+                    // If nothing's equipped in this slot, update the appropriate label.
                     if (eq.equipmentSlots.get(i).itemRefs.get(j) == EntityRef.NULL) {
 
                         if (eq.equipmentSlots.get(i).numSlotsOfSameType == 1) {
@@ -214,19 +221,20 @@ public class CharacterScreenWindow extends BaseInteractionScreen {
                         else {
                             eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + " #" + (j + 1) + ": None");
                         }
-                    } else {
+                    }
+                    // If something's equipped in this slot, update the appropriate label.
+                    else {
 
                         if (eq.equipmentSlots.get(i).numSlotsOfSameType == 1) {
-                            //eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + ": None");
                             eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + ": " +
                                     eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(DisplayNameComponent.class).name);
                         }
                         else {
-                            //eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + "#" + (i + 1) + ": None");
                             eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + " #" + (j + 1) + ": " +
                                     eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(DisplayNameComponent.class).name);
                         }
 
+                        // Add the stat bonuses from the equipped item.
                         phyAtkTotal +=
                                 eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(EquipmentItemComponent.class).attack;
                         phyDefTotal +=
@@ -235,22 +243,12 @@ public class CharacterScreenWindow extends BaseInteractionScreen {
                                 eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(EquipmentItemComponent.class).speed;
                     }
 
+                    // As we are done with this equipment slot (and associated label), increment the counter.
                     c++;
                 }
-
-                /*
-                if (eq.equipmentSlots.get(i).itemRef == EntityRef.NULL) {
-                    eqSlotLabels.get(i).setText(eq.equipmentSlots.get(i).name + ": None");
-                } else {
-                    eqSlotLabels.get(i).setText(eq.equipmentSlots.get(i).name + ": " +
-                            eq.equipmentSlots.get(i).itemRef.getComponent(DisplayNameComponent.class).name);
-                    phyAtkTotal += eq.equipmentSlots.get(i).itemRef.getComponent(EquipmentItemComponent.class).attack;
-                    phyDefTotal += eq.equipmentSlots.get(i).itemRef.getComponent(EquipmentItemComponent.class).defense;
-                    speedTotal += eq.equipmentSlots.get(i).itemRef.getComponent(EquipmentItemComponent.class).speed;
-                }
-                */
             }
 
+            // Update the labels of the derived stats.
             physicalAttackPower.setText("Physical Attack: " + (phyAtkTotal + (strTemp / 2)));
             physicalDefensePower.setText("Physical Defense: " + (phyDefTotal + (defense / 2)));
             magicalAttackPower.setText("Magic Attack: " + (0 + (thaumacity / 2)));

--- a/src/main/java/org/terasology/equipment/ui/CharacterScreenWindow.java
+++ b/src/main/java/org/terasology/equipment/ui/CharacterScreenWindow.java
@@ -109,15 +109,24 @@ public class CharacterScreenWindow extends BaseInteractionScreen {
         EquipmentComponent eqC = player.getComponent(EquipmentComponent.class);
         playerEQInventory.setTargetEntity(eqC.equipmentInventory);
         playerEQInventory.setCellOffset(0);
-        playerEQInventory.setMaxCellCount(eqC.equipmentSlots.size());
+        playerEQInventory.setMaxCellCount(eqC.numberOfSlots);
 
         eqSlotLabels = new ArrayList<UILabel>();
         eqSlotLabelsLayout = find("eqSlotNamesLayout", ColumnLayout.class);
         for (EquipmentSlot equipmentSlot : eqC.equipmentSlots) {
-            UILabel newLabel = new UILabel();
-            newLabel.setText(equipmentSlot.name + ": None");
-            eqSlotLabelsLayout.addWidget(newLabel);
-            eqSlotLabels.add(newLabel);
+            for (int i = 0; i < equipmentSlot.numSlotsOfSameType; i++) {
+                UILabel newLabel = new UILabel();
+
+                if (equipmentSlot.numSlotsOfSameType == 1) {
+                    newLabel.setText(equipmentSlot.name + ": None");
+                }
+                else {
+                    newLabel.setText(equipmentSlot.name + " #" + (i + 1) + ": None");
+                }
+
+                eqSlotLabelsLayout.addWidget(newLabel);
+                eqSlotLabels.add(newLabel);
+            }
         }
     }
 
@@ -194,7 +203,42 @@ public class CharacterScreenWindow extends BaseInteractionScreen {
 
             maxHealth.setText("Health: " + phy.constitution*10);
 
-            for (int i = 0; (i < eqSlotLabels.size()) && (i < eq.equipmentSlots.size()); i++) {
+            int c = 0;
+            for (int i = 0; (i < eq.equipmentSlots.size()); i++) {
+                for (int j = 0; j < eq.equipmentSlots.get(i).numSlotsOfSameType; j++) {
+                    if (eq.equipmentSlots.get(i).itemRefs.get(j) == EntityRef.NULL) {
+
+                        if (eq.equipmentSlots.get(i).numSlotsOfSameType == 1) {
+                            eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + ": None");
+                        }
+                        else {
+                            eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + " #" + (j + 1) + ": None");
+                        }
+                    } else {
+
+                        if (eq.equipmentSlots.get(i).numSlotsOfSameType == 1) {
+                            //eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + ": None");
+                            eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + ": " +
+                                    eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(DisplayNameComponent.class).name);
+                        }
+                        else {
+                            //eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + "#" + (i + 1) + ": None");
+                            eqSlotLabels.get(c).setText(eq.equipmentSlots.get(i).name + " #" + (j + 1) + ": " +
+                                    eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(DisplayNameComponent.class).name);
+                        }
+
+                        phyAtkTotal +=
+                                eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(EquipmentItemComponent.class).attack;
+                        phyDefTotal +=
+                                eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(EquipmentItemComponent.class).defense;
+                        speedTotal +=
+                                eq.equipmentSlots.get(i).itemRefs.get(j).getComponent(EquipmentItemComponent.class).speed;
+                    }
+
+                    c++;
+                }
+
+                /*
                 if (eq.equipmentSlots.get(i).itemRef == EntityRef.NULL) {
                     eqSlotLabels.get(i).setText(eq.equipmentSlots.get(i).name + ": None");
                 } else {
@@ -204,6 +248,7 @@ public class CharacterScreenWindow extends BaseInteractionScreen {
                     phyDefTotal += eq.equipmentSlots.get(i).itemRef.getComponent(EquipmentItemComponent.class).defense;
                     speedTotal += eq.equipmentSlots.get(i).itemRef.getComponent(EquipmentItemComponent.class).speed;
                 }
+                */
             }
 
             physicalAttackPower.setText("Physical Attack: " + (phyAtkTotal + (strTemp / 2)));


### PR DESCRIPTION
### Contains

Now, one can have multiple slots of the same type on their person. For instance, multiple Hands or Fingers slots, instead of the limitation of one before. 
### Future updates

Will add more comments. Also replace the CopperRing graphic with the image of an actual ring.
### How to test

Spawn three Copper Rings, and play around with equipping, unequipping, and swapping them in the Character Screen equipment inventory.
