### PR TITLE
Updated CharacterScreen.skin and CraftingStation.skin font

### DIFF
--- a/assets/skins/CharacterScreen.skin
+++ b/assets/skins/CharacterScreen.skin
@@ -6,7 +6,7 @@
             "background" : "greyedBackground"
         },
         "UILabel" : {
-            "font" : "title"
+            "font" : "NotoSans-Regular-Large"
         },
         "ScrollableArea": {
             "background": "",

--- a/assets/skins/CraftingStation.skin
+++ b/assets/skins/CraftingStation.skin
@@ -6,7 +6,7 @@
             "background" : "greyedBackground"
         },
         "UILabel" : {
-            "font" : "title"
+            "font" : "NotoSans-Regular-Large"
         },
         "ScrollableArea": {
             "background": "",


### PR DESCRIPTION
Updated CharacterScreen.skin and CraftingStation.skin to use 'NotoSans-Regular-Large' as the font instead of 'title' per issue #2472

I found no mention of the 'default' font to change in those files.

I searched for more uses of title font in skin files in modules, but found none. Perhaps my grep-fu was weak though.
