### PR TITLE
Added support for AlterationEffects

### DIFF
--- a/assets/prefabs/Equipment/Copper/CopperRingOfHealing.prefab
+++ b/assets/prefabs/Equipment/Copper/CopperRingOfHealing.prefab
@@ -1,0 +1,26 @@
+{
+    "parent" : "engine:iconItem",
+    "Item" : {
+        "icon" : "Equipment:CopperRing"
+    },
+    "DisplayName" : {
+        "name" : "Copper Ring of Health",
+        "description" : "An ornamental ring made out of copper. Applies health regen."
+    },
+    "EquipmentItem" : {
+        "level" : 2,
+        "quality" : 3,
+        "type" : "Ring",
+        "location" : "Ring",
+        "attack" : 0,
+        "defense" : 2,
+        "weight" : 0,
+        "speed" : 0
+    },
+    "RegenEffect" : {
+        "magnitude" : 30,
+        "duration" : 10000,
+        "affectsUser" : true,
+        "affectsEnemies" : false
+    }
+}

--- a/module.txt
+++ b/module.txt
@@ -12,6 +12,10 @@
         {
             "id" : "PhysicalStats",
             "minVersion" : "0.1.0"
+        },
+        {
+            "id" : "AlterationEffects",
+            "minVersion" : "0.2.0"
         }
 
     ],

--- a/src/main/java/org/terasology/equipment/component/EquipmentEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/EquipmentEffectComponent.java
@@ -17,21 +17,20 @@ package org.terasology.equipment.component;
 
 import org.terasology.entitySystem.Component;
 
-public class EquipmentEffectComponent{
-    /**
-     * the duration for which the effect lasts
-     */
-    public int duration = 0;
-    /**
-     * the magnitude of the effect
-     */
-    public int magnitude = 0;
-    /**
-     * whether the effect affects the entity which equips the item
-     */
+public class EquipmentEffectComponent implements Component {
+
+    //the duration for which the effect lasts
+    public int duration;
+
+    //the magnitude of the effect
+    public int magnitude;
+
+     //whether the effect affects the entity which equips the item
     public boolean affectsUser;
-    /**
-     * whether the effect affects enemies damaged by the item
-     */
+
+     //whether the effect affects enemies damaged by the item
     public boolean affectsEnemies;
+
+    //optional id for certain effects
+    public String id;
 }

--- a/src/main/java/org/terasology/equipment/component/EquipmentEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/EquipmentEffectComponent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.equipment.component;
+
+import org.terasology.entitySystem.Component;
+
+public class EquipmentEffectComponent{
+    /**
+     * the duration for which the effect lasts
+     */
+    public int duration = 0;
+    /**
+     * the magnitude of the effect
+     */
+    public int magnitude = 0;
+    /**
+     * whether the effect affects the entity which equips the item
+     */
+    public boolean affectsUser;
+    /**
+     * whether the effect affects enemies damaged by the item
+     */
+    public boolean affectsEnemies;
+}

--- a/src/main/java/org/terasology/equipment/component/effects/BoostEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/BoostEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class BoostEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/BreathingEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/BreathingEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class BreathingEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/CureDamageOverTimeEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/CureDamageOverTimeEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class CureDamageOverTimeEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/DamageOverTimeEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/DamageOverTimeEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class DamageOverTimeEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/DecoverEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/DecoverEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class DecoverEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/ItemUseSpeedEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/ItemUseSpeedEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class ItemUseSpeedEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/JumpSpeedEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/JumpSpeedEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class JumpSpeedEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/MultiJumpEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/MultiJumpEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class MultiJumpEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/RegenEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/RegenEffectComponent.java
@@ -15,8 +15,7 @@
  */
 package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class RegenEffectComponent extends EquipmentEffectComponent implements Component {
+public class RegenEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/RegenEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/RegenEffectComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.equipment.component.effects;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
+
+public class RegenEffectComponent extends EquipmentEffectComponent implements Component {
+}

--- a/src/main/java/org/terasology/equipment/component/effects/ResistEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/ResistEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class ResistEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/StunEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/StunEffectComponent.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.equipment.component.EquipmentEffectComponent;
 
 public class StunEffectComponent extends EquipmentEffectComponent {

--- a/src/main/java/org/terasology/equipment/component/effects/StunEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/StunEffectComponent.java
@@ -18,5 +18,5 @@ package org.terasology.equipment.component.effects;
 import org.terasology.entitySystem.Component;
 import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class StunEffectComponent extends EquipmentEffectComponent implements Component{
+public class StunEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/StunEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/StunEffectComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.equipment.component.effects;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
+
+public class StunEffectComponent extends EquipmentEffectComponent implements Component{
+}

--- a/src/main/java/org/terasology/equipment/component/effects/SwimSpeedEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/SwimSpeedEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class SwimSpeedEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/component/effects/WalkSpeedEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/WalkSpeedEffectComponent.java
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.equipment.component;
+package org.terasology.equipment.component.effects;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.equipment.component.EquipmentEffectComponent;
 
-public class EquipmentEffectComponent implements Component {
-
-    /** the duration for which the effect lasts */
-    public int duration;
-
-    /** the magnitude of the effect */
-    public int magnitude;
-
-    /** whether the effect affects the entity which equips the item */
-    public boolean affectsUser;
-
-    /** whether the effect affects enemies damaged by the item */
-    public boolean affectsEnemies;
-
-    /** optional id for certain effects */
-    public String id;
+public class WalkSpeedEffectComponent extends EquipmentEffectComponent {
 }

--- a/src/main/java/org/terasology/equipment/system/EquipmentEffectsSystem.java
+++ b/src/main/java/org/terasology/equipment/system/EquipmentEffectsSystem.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.equipment.system;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.alterationEffects.AlterationEffect;
+import org.terasology.alterationEffects.regenerate.RegenerationAlterationEffect;
+import org.terasology.alterationEffects.regenerate.RegenerationComponent;
+import org.terasology.alterationEffects.speed.*;
+import org.terasology.context.Context;
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.equipment.component.effects.RegenEffectComponent;
+import org.terasology.equipment.component.effects.StunEffectComponent;
+import org.terasology.equipment.component.EquipmentComponent;
+import org.terasology.equipment.component.EquipmentEffectComponent;
+import org.terasology.equipment.event.EquipItemEvent;
+import org.terasology.equipment.event.UnequipItemEvent;
+import org.terasology.logic.health.BeforeDamagedEvent;
+import org.terasology.registry.In;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+@RegisterSystem
+public class EquipmentEffectsSystem extends BaseComponentSystem {
+
+    @In
+    private Context context;
+
+    Logger logger = LoggerFactory.getLogger(EquipmentEffectsSystem.class);
+
+    /**
+     * Maps the EquipmentEffectComponents to their corresponding EffectComponent so that
+     * 1. the system knows which EquipmentEffectComponents to look out for
+     * 2. the system knows which EffectComponents to remove from the entity
+     */
+    private Map<Class, Class<? extends  Component>> effectComponents = new HashMap<>();
+
+    @Override
+    public void initialise() {
+        effectComponents.put(StunEffectComponent.class, StunComponent.class);
+        effectComponents.put(RegenEffectComponent.class, RegenerationComponent.class);
+    }
+
+    @ReceiveEvent
+    public void onEquip(EquipItemEvent event, EntityRef entity, EquipmentComponent eq) {
+        for (Entry<Class, Class<? extends Component>> entry: effectComponents.entrySet()){
+            if (event.getItem().hasComponent(entry.getKey())) {
+                EquipmentEffectComponent eec = (EquipmentEffectComponent) event.getItem().getComponent(entry.getKey());
+                if (eec != null && eec.affectsUser){
+                    applyEffect(eec,entity,entity);
+                }
+            }
+        }
+    }
+
+    @ReceiveEvent
+    public void onUnequip(UnequipItemEvent event, EntityRef entity, EquipmentComponent eq) {
+        for (Entry<Class, Class<? extends Component>> entry: effectComponents.entrySet()){
+            EquipmentEffectComponent eec = (EquipmentEffectComponent) event.getItem().getComponent(entry.getKey());
+            if (eec != null && eec.affectsUser){
+                entity.removeComponent(entry.getValue());
+            }
+        }
+    }
+
+    @ReceiveEvent
+    public void takingDamage(BeforeDamagedEvent event, EntityRef damageTarget) {
+        EntityRef item = event.getDirectCause();
+        for (Entry<Class, Class<? extends Component>> entry: effectComponents.entrySet()){
+            EquipmentEffectComponent eec = (EquipmentEffectComponent) item.getComponent(entry.getKey());
+            if (eec != null && eec.affectsEnemies ){
+                applyEffect(eec,event.getInstigator(),damageTarget);
+            }
+        }
+    }
+
+    public void applyEffect(EquipmentEffectComponent eec, EntityRef instigator, EntityRef entity){
+        AlterationEffect alterationEffect = null;
+        if (eec.getClass() == StunEffectComponent.class)
+            alterationEffect = new StunAlterationEffect(context);
+        else if (eec.getClass() == RegenEffectComponent.class)
+            alterationEffect = new RegenerationAlterationEffect(context);
+
+        if (alterationEffect != null)
+            alterationEffect.applyEffect(instigator,entity,eec.magnitude,eec.duration);
+    }
+}


### PR DESCRIPTION
## Contains

I don't think this is ready for a merge yet but I've added a system for handling all the equipment effects and would like to see what you guys think about it. I tried it to write such that it's very simple to add new effect components. All equipment effect components should extend EquipmentEffectComponent which contains fields such as the magnitude and duration of the effect.

The main problem I faced was linking the equipment effect components to the effect components and alteration effect instances so I ended up using a Map for this. I commented on some parts of the code to explain what certain things are for.

## How to Test
I've added the stun and health regen effect as equipment components and a Copper Ring of Healing prefab to test the code out.

1. Give yourself a CopperRingOfHealing and damage yourself
2. Put the ring on

## Issues
There are a few things I think can be added to AlterationEffects to better integrate it.
- removeEffect method to the alterationEffect interface so that any effect can easily removed without requiring the component (this would remove the need for a Map in my code I think)
- DURATION_INDEFINITE value for using with applyEffect. I feel that this would be important for equipment pieces with effects.

Let me know if you agree with any of these and I will send it as a PR. I think that this system offers great flexibility and will vastly increase the possibilties for items (medigun!). Do tell me if there are any problems with the code and my code style 😄. 