### PR TITLE
Remove illegal character (Whitespace)

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,7 +1,7 @@
 {
     "id" : "Equipment",
     "version" : "1.0.0-SNAPSHOT",
-    "author" : "XTariq, Aditya Singh, ElBatanony, Gautam Naik, iojw (Isaac), Mandar Juvekar, gkaretka, Patrick Wang, smsunarto, Arpit Kamboj(digitalripperynr), Tim Verhaegen (xTimPugz), kallentu, Minege, NicholasBatesNZ,SufurElite, He Who Shall Not Be Named (VaibhavBajaj), meganyyu, PokeyOne, Marvel0usx",
+    "author" : "XTariq, Aditya Singh, ElBatanony, Gautam Naik, iojw (Isaac), Mandar Juvekar, gkaretka, Patrick Wang, smsunarto, Arpit Kamboj(digitalripperynr), Tim Verhaegen (xTimPugz), kallentu, Minege, NicholasBatesNZ,SufurElite, He Who Shall Not Be Named (VaibhavBajaj), meganyyu, PokeyOne, Marvel0usx",
     "displayName" : "Equipment",
     "description" : "A basic system allowing for characters to have equipment.",
     "dependencies" : [


### PR DESCRIPTION
There's an illegal whitespace that prevents the game from running with this module in the `/modules` directory.