### PR TITLE
Added multiple damage types to Resist effect and copper ring

### DIFF
--- a/assets/prefabs/Equipment/Copper/CopperRingOfPoisonPhysicalResist.prefab
+++ b/assets/prefabs/Equipment/Copper/CopperRingOfPoisonPhysicalResist.prefab
@@ -1,0 +1,36 @@
+{
+    "parent" : "engine:iconItem",
+    "Item" : {
+        "icon" : "Equipment:CopperRing"
+    },
+    "DisplayName" : {
+        "name" : "Copper Ring of Regen",
+        "description" : "An ornamental ring made out of copper. Increases poison and physical resist by 3 and 2 respectively while equipped."
+    },
+    "EquipmentItem" : {
+        "level" : 2,
+        "quality" : 3,
+        "type" : "Ring",
+        "location" : "Ring",
+        "attack" : 0,
+        "defense" : 2,
+        "weight" : 0,
+        "speed" : 0
+    },
+    "ResistEffect" : {
+        "magnitude" : 2,
+        "duration" : -1,
+        "affectsUser" : true,
+        "affectsEnemies" : false,
+        "resistances": {
+            "AlterationEffects:poisonDamage": {
+                "resistType": "AlterationEffects:poisonDamage",
+                "resistAmount": 3
+            },
+            "engine:physicalDamage": {
+                "resistType": "engine:physicalDamage",
+                "resistAmount": 2
+            }
+        }
+    }
+}

--- a/assets/prefabs/Equipment/Copper/CopperRingOfPoisonPhysicalResist.prefab
+++ b/assets/prefabs/Equipment/Copper/CopperRingOfPoisonPhysicalResist.prefab
@@ -23,13 +23,13 @@
         "affectsUser" : true,
         "affectsEnemies" : false,
         "resistances": {
-            "AlterationEffects:poisonDamage": {
-                "resistType": "AlterationEffects:poisonDamage",
-                "resistAmount": 3
-            },
-            "engine:physicalDamage": {
-                "resistType": "engine:physicalDamage",
+            "poisonDamage": {
+                "resistType": "poisonDamage",
                 "resistAmount": 2
+            },
+            "physicalDamage": {
+                "resistType": "physicalDamage",
+                "resistAmount": 5
             }
         }
     }

--- a/src/main/java/org/terasology/equipment/component/effects/ResistEffectComponent.java
+++ b/src/main/java/org/terasology/equipment/component/effects/ResistEffectComponent.java
@@ -15,7 +15,16 @@
  */
 package org.terasology.equipment.component.effects;
 
+import org.terasology.alterationEffects.resist.ResistDamageEffect;
 import org.terasology.equipment.component.EquipmentEffectComponent;
+import org.terasology.network.Replicate;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ResistEffectComponent extends EquipmentEffectComponent {
+
+    /** Stores the map of damage type class name to resistances. */
+    @Replicate
+    public Map<String, ResistDamageEffect> resistances = new HashMap<>();
 }


### PR DESCRIPTION
Added multiple damage type resistances in the `ResistEffectComponent`.
Added a `CopperRingOfPoisonPhysicalResist` which resists both Poison and Physical damage types.

I'm having some trouble testing it, still made the PR so that it can be reviewed or tested by others. I made an [engine PR](https://github.com/MovingBlocks/Terasology/pull/2952) that might help in testing this.