### PR TITLE
Change CC dependency from optional to hard

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -6,7 +6,7 @@
     "description": "A basic system allowing for characters to have equipment.\n\nAlso, lots of equipment assets.",
     "dependencies": [
         { "id": "AlterationEffects", "minVersion": "1.1.0" },
-        { "id": "ClimateConditions", "minVersion": "1.0.0", "optional": true },
+        { "id": "ClimateConditions", "minVersion": "1.0.0" },
         { "id": "Health", "minVersion": "1.0.0" },
         { "id": "Inventory", "minVersion": "1.1.0" },
         { "id": "ManualLabor", "minVersion": "1.3.0", "optional": true },


### PR DESCRIPTION
This PR converts an "optional" dependency on CC to a hard one.
The EquipmentsEffectsSystem directly imports BodyTemperatureAlterationEffect from CC and therefore the dependency can on longer remain optional.